### PR TITLE
Add number of mutants killed to fuzz log

### DIFF
--- a/src/main/java/cmu/pasta/mu2/fuzz/MutationCoverage.java
+++ b/src/main/java/cmu/pasta/mu2/fuzz/MutationCoverage.java
@@ -38,11 +38,11 @@ public class MutationCoverage extends Coverage {
     return caughtMutants.size();
   }
 
-  public boolean updateMutants(MutationCoverage that) {
+  public int updateMutants(MutationCoverage that) {
     int prevSize = caughtMutants.size();
     caughtMutants.addAll(that.caughtMutants);
     seenMutants.addAll(that.seenMutants);
-    return caughtMutants.size() > prevSize;
+    return caughtMutants.size() - prevSize;
   }
 
   public int numSeenMutants() {

--- a/src/main/java/cmu/pasta/mu2/fuzz/MutationGuidance.java
+++ b/src/main/java/cmu/pasta/mu2/fuzz/MutationGuidance.java
@@ -118,8 +118,9 @@ public class MutationGuidance extends ZestGuidance {
   @Override
   protected List<String> checkSavingCriteriaSatisfied(Result result) {
     List<String> criteria = super.checkSavingCriteriaSatisfied(result);
-    if (((MutationCoverage) totalCoverage).updateMutants(((MutationCoverage) runCoverage))) {
-      criteria.add("+mutants");
+    int newKilledMutants = ((MutationCoverage) totalCoverage).updateMutants(((MutationCoverage) runCoverage));
+    if (newKilledMutants > 0) {
+      criteria.add(String.format("+%d mutants", newKilledMutants));
     }
 
     // TODO: Add responsibilities for mutants killed


### PR DESCRIPTION
Add # mutants killed to fuzz log, e.g. "+10 mutants" rather than "+ mutants". Helps debug which inputs are important.

From sample run:
```
Saved - /usr0/home/vvikram/Work/sort-benchmarks/target/test/corpus/id_000010 src:000000,havoc:3 +count +cov +valid +11 mutants
```