### PR TITLE
add exceptions to fuzz log

### DIFF
--- a/src/main/java/cmu/pasta/mu2/fuzz/MutationGuidance.java
+++ b/src/main/java/cmu/pasta/mu2/fuzz/MutationGuidance.java
@@ -89,6 +89,8 @@ public class MutationGuidance extends ZestGuidance {
    */
   private static ArraySet runMutants = new ArraySet();
 
+  private final List<String> exceptions = new ArrayList<>();
+
   public MutationGuidance(String testName, MutationClassLoaders mutationClassLoaders,
       Duration duration, Long trials, File outputDirectory, File seedInputDir, Random rand)
       throws IOException {
@@ -120,7 +122,7 @@ public class MutationGuidance extends ZestGuidance {
     List<String> criteria = super.checkSavingCriteriaSatisfied(result);
     int newKilledMutants = ((MutationCoverage) totalCoverage).updateMutants(((MutationCoverage) runCoverage));
     if (newKilledMutants > 0) {
-      criteria.add(String.format("+%d mutants", newKilledMutants));
+      criteria.add(String.format("+%d mutants %s", newKilledMutants, exceptions.toString()));
     }
 
     // TODO: Add responsibilities for mutants killed
@@ -134,6 +136,7 @@ public class MutationGuidance extends ZestGuidance {
     numRuns++;
     runMutants.reset();
     MutationSnoop.setMutantCallback(m -> runMutants.add(m.id));
+    exceptions.clear();
 
     long startTime = System.currentTimeMillis();
 
@@ -174,6 +177,7 @@ public class MutationGuidance extends ZestGuidance {
         if (!isExceptionExpected(e.getClass(), expectedExceptions)) {
           // failed
           deadMutants.add(mutationInstance.id);
+          exceptions.add(e.getClass().getName());
 
           ((MutationCoverage) runCoverage).kill(mutationInstance);
           fails.add(e);


### PR DESCRIPTION
This adds the names of the `Throwable` classes - we could instead add the `Throwable` `toString()` itself, which gives more details, but the fuzz log starts to be very long, and I think, at the moment, we're primarily looking at what kinds of errors, not what exactly happened in the mutant.