### PR TITLE
Delete double increment trials for MutationGuidance

### DIFF
--- a/src/main/java/cmu/pasta/mu2/fuzz/MutationGuidance.java
+++ b/src/main/java/cmu/pasta/mu2/fuzz/MutationGuidance.java
@@ -130,7 +130,6 @@ public class MutationGuidance extends ZestGuidance {
 
   @Override
   public void run(TestClass testClass, FrameworkMethod method, Object[] args) throws Throwable {
-    numTrials++;
     numRuns++;
     runMutants.reset();
     MutationSnoop.setMutantCallback(m -> runMutants.add(m.id));

--- a/src/test/java/cmu/pasta/mu2/fuzz/MutationGuidanceIT.java
+++ b/src/test/java/cmu/pasta/mu2/fuzz/MutationGuidanceIT.java
@@ -83,7 +83,7 @@ public class MutationGuidanceIT extends AbstractMutationTest {
     GuidedFuzzing.run(testClassName, testMethod, mcls.getCartographyClassLoader(), mu2, null);
 
 
-    Assert.assertEquals(15, mu2.corpusCount());
+    Assert.assertEquals(22, mu2.corpusCount());
 
 
   }


### PR DESCRIPTION
Deletes [this line](https://github.com/cmu-pasta/mu2/blob/main/src/main/java/cmu/pasta/mu2/fuzz/MutationGuidance.java#L133), since number of trials is already incremented in `ZestGuidance` [here](https://github.com/rohanpadhye/JQF/blob/master/fuzz/src/main/java/edu/berkeley/cs/jqf/fuzz/ei/ZestGuidance.java#L717).