### PR TITLE
Update display stats signature for MutationGuidance

### DIFF
--- a/src/main/java/cmu/pasta/mu2/fuzz/MutationGuidance.java
+++ b/src/main/java/cmu/pasta/mu2/fuzz/MutationGuidance.java
@@ -206,7 +206,7 @@ public class MutationGuidance extends ZestGuidance {
   }
 
   @Override
-  protected void displayStats() {
+  protected void displayStats(boolean force) {
     Date now = new Date();
     long intervalTime = now.getTime() - lastRefreshTime.getTime();
     long totalTime = now.getTime() - startTime.getTime();


### PR DESCRIPTION
With change to `displayStats` signature in `ZestGuidance`, need to update overridden method in `MutationGuidance`.