### PR TITLE
Add @Fuzz handling for diff framework

### DIFF
--- a/src/main/java/cmu/pasta/mu2/diff/Mu2.java
+++ b/src/main/java/cmu/pasta/mu2/diff/Mu2.java
@@ -3,6 +3,7 @@ package cmu.pasta.mu2.diff;
 import cmu.pasta.mu2.diff.guidance.DiffGuidance;
 import cmu.pasta.mu2.diff.guidance.DiffNoGuidance;
 import cmu.pasta.mu2.diff.junit.DiffedFuzzing;
+import edu.berkeley.cs.jqf.fuzz.Fuzz;
 import edu.berkeley.cs.jqf.fuzz.JQF;
 import edu.berkeley.cs.jqf.fuzz.junit.GuidedFuzzing;
 import edu.berkeley.cs.jqf.fuzz.junit.quickcheck.FuzzStatement;
@@ -74,7 +75,7 @@ public class Mu2 extends JQF {
 
     @Override
     public Statement methodBlock(FrameworkMethod method) {
-        if (method.getAnnotation(Diff.class) == null) {
+        if (method.getAnnotation(Diff.class) == null && method.getAnnotation(Fuzz.class) == null) {
             return super.methodBlock(method);
         }
 
@@ -85,7 +86,7 @@ public class Mu2 extends JQF {
             guidance = new DiffNoGuidance(GuidedFuzzing.DEFAULT_MAX_TRIALS, System.err);
         }
 
-        if(!method.getAnnotation(Diff.class).cmp().equals("")) {
+        if(method.getAnnotation(Diff.class) != null && !method.getAnnotation(Diff.class).cmp().equals("")) {
             guidance.setCompare(cmpNames.get(method.getAnnotation(Diff.class).cmp()).getMethod());
         }
 

--- a/src/test/java/cmu/pasta/mu2/diff/DiffIT.java
+++ b/src/test/java/cmu/pasta/mu2/diff/DiffIT.java
@@ -120,6 +120,25 @@ public class DiffIT extends AbstractMutationTest {
     }
 
     @Test
+    public void fuzzTimSort() throws Exception {
+        // Set up test params
+        String testClassName = "diff.DiffTest";
+        String testMethod = "fuzzTimSort";
+        String targetInst = "sort.TimSort";
+        long trials = 100;
+        Random rnd = new Random(42);
+
+        // Create guidance
+        MutationClassLoaders mcls = initClassLoaders(targetInst, OptLevel.NONE);
+        ProbedMutationGuidance mu2 = new ProbedMutationGuidance(mcls, trials, rnd);
+
+        // Fuzz
+        DiffedFuzzing.run(testClassName, testMethod, mcls.getCartographyClassLoader(), mu2, null);
+
+        Assert.assertEquals(36, mu2.corpusCount());
+    }
+
+    @Test
     public void noncompareTimSort() throws Exception {
         // Set up test params
         String testClassName = "diff.DiffTest";


### PR DESCRIPTION
Must be merged after [this PR](https://github.com/cmu-pasta/sort-benchmarks/pull/2). 

Allows for `@Fuzz` targets to be used with the differential testing framework. 

Currently, for an `@Fuzz` annotated method, [these lines](https://github.com/cmu-pasta/mu2/blob/main/src/main/java/cmu/pasta/mu2/diff/Mu2.java#L77-L79) will be called in `Mu2.java`:

```
    if (method.getAnnotation(Diff.class) == null) {
        return super.methodBlock(method);
    }
```
This will result in [these lines](https://github.com/rohanpadhye/JQF/blob/mu2/fuzz/src/main/java/edu/berkeley/cs/jqf/fuzz/JQF.java#L94-L99) called in `JQF.java`:
```
    if (method.getAnnotation(Fuzz.class) == null) {
        return super.methodBlock(method);
    }


    // Get currently set fuzzing guidance
    Guidance guidance = GuidedFuzzing.getCurrentGuidance();
```

However, the guidance is set in `DiffedFuzzing`, not `GuidedFuzzing`, so this will return no guidance. We need to fetch the guidance from `DiffedFuzzing`, so we should not call `super.methodBlock(method)`.

Integration test with `fuzzTimSort` shows the same number of inputs saved as the other `TimSort` integration tests.