### PR TITLE
Add mutant execution map for Mu2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ cycler==0.10.0
 kiwisolver==1.3.2
 matplotlib==3.4.3
 matplotlib-venn==0.11.6
+mplcursors==0.5.2
 numpy==1.21.2
 pandas==1.3.3
 Pillow==8.3.2
@@ -9,4 +10,6 @@ pyparsing==2.4.7
 python-dateutil==2.8.2
 pytz==2021.1
 scipy==1.7.1
+seaborn==0.12.1
 six==1.16.0
+z3-solver==4.8.15.0

--- a/scripts/plot_mutant_execution.py
+++ b/scripts/plot_mutant_execution.py
@@ -1,0 +1,21 @@
+from mplcursors import cursor
+import pandas as pd
+import matplotlib.pyplot as plt
+import seaborn as sns
+import argparse
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("mutant_execution_file")
+
+
+    args = parser.parse_args()
+    df = pd.read_csv(args.mutant_execution_file)
+
+    ax = sns.relplot(data=df, x='execution_count', y='mutant', hue='killed')
+    plt.title("Mutant Execution Counts")
+    plt.xlabel("Execution Count")
+    plt.ylabel("Mutants")
+    plt.yticks([])
+    cursor(hover=True)
+    plt.show()

--- a/scripts/plot_mutant_execution.py
+++ b/scripts/plot_mutant_execution.py
@@ -2,6 +2,7 @@ from mplcursors import cursor
 import pandas as pd
 import matplotlib.pyplot as plt
 import seaborn as sns
+import numpy as np
 import argparse
 
 if __name__ == "__main__":
@@ -11,8 +12,9 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
     df = pd.read_csv(args.mutant_execution_file)
+    df['execution_count_log'] = np.log10(df['execution_count'])
 
-    ax = sns.relplot(data=df, x='execution_count', y='mutant', hue='killed')
+    ax = sns.relplot(data=df, x='execution_count_log', y='mutant', hue='killed')
     plt.title("Mutant Execution Counts")
     plt.xlabel("Execution Count")
     plt.ylabel("Mutants")


### PR DESCRIPTION
Writes mutant execution map at the end of campaign to `outputDirectory/mutant_execution_counts.csv`. 

Adds script to plot mutants, execution count, and whether it was killed. Example:
![image](https://user-images.githubusercontent.com/3836748/205514127-db216a71-04aa-414d-83e2-5e47d92669f0.png)
